### PR TITLE
[#10] Generate one goroutine for each StreamID to process the message.

### DIFF
--- a/client/awsclient.go
+++ b/client/awsclient.go
@@ -107,7 +107,7 @@ type AWSClientOptions struct {
 	// TLSConfig If you want to customize tls.Config, set the value. Otherwise it sets null.
 	TLSConfig *tls.Config
 
-	// DialTimeout sets the timeout value when connecting to websocket.
+	// DialTimeout sets the timeout value when connecting to the service.
 	DialTimeout time.Duration
 
 	// ReconnectInterval represents the interval when reconnecting.

--- a/client/worker.go
+++ b/client/worker.go
@@ -1,0 +1,72 @@
+package client
+
+import "context"
+
+// Worker is a structure that has one channel and manages one goroutine.
+// You can write function to the channel using Exec().
+// The function is executed sequentially by the internal goroutine.
+// This structure cannot be reused.
+type Worker struct {
+	exec      chan func(context.Context)
+	terminate chan struct{}
+	cancel    chan context.CancelFunc
+}
+
+// NewWorker returns a Worker instance.
+// bufSize -> channel buffer size.
+func NewWorker(bufSize int) *Worker {
+
+	instance := &Worker{
+		exec:      make(chan func(context.Context), bufSize),
+		terminate: make(chan struct{}, 1),
+		cancel:    make(chan context.CancelFunc, 1),
+	}
+
+	return instance
+}
+
+// Start goroutine and execute functions in channel sequentially.
+func (worker *Worker) Start(ctx context.Context) {
+
+	ctx, cancel := context.WithCancel(ctx)
+	worker.cancel <- cancel
+
+	go func() {
+		defer close(worker.terminate)
+
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case fnc := <-worker.exec:
+				fnc(ctx)
+			}
+		}
+	}()
+}
+
+// Run is a method that behaves like Start().
+// This medhod does not return control to the caller until the following phenomenons occur.
+// 	- caller context is done.
+// 	- Stop() method.
+func (worker *Worker) Run(ctx context.Context) {
+	worker.Start(ctx)
+	<-worker.terminate
+}
+
+// Exec is a function for writing functions to be executed sequentially.
+func (worker *Worker) Exec(fnc func(context.Context)) {
+	worker.exec <- fnc
+}
+
+// Stop inner goroutine.
+func (worker *Worker) Stop() {
+
+	cancel, ok := <-worker.cancel
+
+	if ok {
+		close(worker.cancel)
+		cancel()
+		<-worker.terminate
+	}
+}

--- a/client/worker_test.go
+++ b/client/worker_test.go
@@ -1,0 +1,67 @@
+package client
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+)
+
+type WorkerTest struct {
+	suite.Suite
+}
+
+func TestWorker(t *testing.T) {
+	suite.Run(t, new(WorkerTest))
+}
+
+// TestWorkerNormal confirm the operation when Worker is used normally.
+func (suite *WorkerTest) TestWorkerNormal() {
+
+	bufSize := 10
+	functionCount := 100
+
+	worker := NewWorker(bufSize)
+	worker.Start(context.Background())
+
+	suite.Require().Equal(bufSize, cap(worker.exec))
+
+	buf := make(chan int, functionCount)
+
+	for i := 0; i < functionCount; i++ {
+		data := i
+		worker.Exec(func(ctx context.Context) {
+			buf <- data
+		})
+	}
+
+	for i := 0; i < functionCount; i++ {
+		actual := <-buf
+		expected := i
+
+		suite.Require().Equal(expected, actual)
+	}
+
+	// Confirm no panic occurs even if Stop() is executed multiple times.
+	worker.Stop()
+	worker.Stop()
+}
+
+func (suite *WorkerTest) TestWorkerContextCancel() {
+
+	worker := NewWorker(10)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go worker.Run(ctx)
+
+	called := make(chan struct{})
+	worker.Exec(func(ctx context.Context) {
+		called <- struct{}{}
+		<-ctx.Done()
+	})
+
+	<-called
+	cancel()
+	<-worker.terminate
+	worker.Stop()
+}

--- a/client/workermanager.go
+++ b/client/workermanager.go
@@ -1,0 +1,86 @@
+package client
+
+import (
+	"context"
+	sync "sync"
+
+	"github.com/mizosukedev/securetunnel/log"
+)
+
+// workerManager is a structure for managing Worker for each StreamID.
+type workerManager struct {
+	workerMap map[int32]*Worker // map[StreamID]*Worker
+	rwMutex   *sync.RWMutex     //
+	bufSize   int               // channel buffer size
+}
+
+// start Worker.
+func (mng *workerManager) start(streamID int32) *Worker {
+
+	mng.rwMutex.Lock()
+	defer mng.rwMutex.Unlock()
+
+	worker := NewWorker(mng.bufSize)
+	worker.Start(context.Background())
+	mng.workerMap[streamID] = worker
+
+	return worker
+}
+
+// exec Worker
+func (mng *workerManager) exec(streamID int32, fnc func(context.Context)) {
+
+	mng.rwMutex.RLock()
+	defer mng.rwMutex.RUnlock()
+
+	worker, ok := mng.workerMap[streamID]
+	if ok {
+		worker.Exec(fnc)
+	} else {
+		log.Warnf("the StreamID has already been reset. StreamID=%d", streamID)
+	}
+}
+
+// stop Worker asynchronously.
+func (mng *workerManager) stop(streamID int32) {
+
+	// The reason why Worker is stopped asynchronously is as follows.
+	// - The Worker to stop may be Worker's goroutine. -> dead lock.
+	// - The timing to stop the Worker does not have to be exact.
+	go func() {
+
+		mng.rwMutex.Lock()
+		defer mng.rwMutex.Unlock()
+
+		worker, ok := mng.workerMap[streamID]
+		if ok {
+			worker.Stop()
+			delete(mng.workerMap, streamID)
+		}
+	}()
+}
+
+// getAll Worker.
+func (mng *workerManager) getAll() []*Worker {
+
+	mng.rwMutex.RLock()
+	defer mng.rwMutex.RUnlock()
+
+	workers := make([]*Worker, 0)
+
+	for _, worker := range mng.workerMap {
+		workers = append(workers, worker)
+	}
+
+	return workers
+}
+
+// stopAll Worker.
+func (mng *workerManager) stopAll() {
+
+	workers := mng.getAll()
+
+	for _, worker := range workers {
+		worker.Stop()
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -5,5 +5,12 @@ go 1.18
 require (
 	github.com/gorilla/websocket v1.5.0
 	github.com/mizosukedev/securetunnel v0.0.0-20220508085114-9ac7383c9c82
+	github.com/stretchr/testify v1.7.1
 	google.golang.org/protobuf v1.28.0
+)
+
+require (
+	github.com/davecgh/go-spew v1.1.0 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
+github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/golang/protobuf v1.5.0/go.mod h1:FsONVRAS9T7sI+LIUmWTfcYkHO4aIWwzhcaSAoJOfIk=
 github.com/google/go-cmp v0.5.5 h1:Khx7svrCpmxxtHBq5j2mp/xVjsi8hQMfNLvJFAlrGgU=
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
@@ -5,8 +7,17 @@ github.com/gorilla/websocket v1.5.0 h1:PPwGk2jz7EePpoHN/+ClbZu8SPxiqlu12wZP/3sWm
 github.com/gorilla/websocket v1.5.0/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 github.com/mizosukedev/securetunnel v0.0.0-20220508085114-9ac7383c9c82 h1:auTpjuVOeE5B6TIBVkkcAmtS+WrOitr8j2GZQ8Hw+Kw=
 github.com/mizosukedev/securetunnel v0.0.0-20220508085114-9ac7383c9c82/go.mod h1:9rSyBSPlOIEI5IKavkMcykTlgVOUTxJviXYL4kl+Ps8=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/testify v1.7.1 h1:5TQK59W5E3v0r2duFAb7P95B6hEeOyEnHRa8MjYSMTY=
+github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543 h1:E7g+9GITq07hpfrRu66IVDexMakfv52eLZ2CXBWiKr4=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 google.golang.org/protobuf v1.26.0-rc.1/go.mod h1:jlhhOSvTdKEhbULTjvd4ARK9grFBp09yW+WbY/TyQbw=
 google.golang.org/protobuf v1.28.0 h1:w43yiav+6bVFTBQFZX0r7ipe9JQ1QsbMgHwbBziscLw=
 google.golang.org/protobuf v1.28.0/go.mod h1:HV8QOd/L58Z+nl8r43ehVNZIU/HEI6OcFqwMG9pJV4I=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=


### PR DESCRIPTION
- メッセージを受信した時にStreamID毎に1つのgoroutineを生成して処理するようにした。
- これにより、StreamID毎に送信用1スレッド、受信用に1スレッドで処理するようになる。