### PR TITLE
[#48] Move constants in client package to aws package.

### DIFF
--- a/_testutil/securetunnel_server.go
+++ b/_testutil/securetunnel_server.go
@@ -13,10 +13,6 @@ import (
 	"google.golang.org/protobuf/proto"
 )
 
-const (
-	sizeOfMessageSize = 2
-)
-
 type ReadMessageResult struct {
 	MessageType int
 	Message     []byte
@@ -26,7 +22,7 @@ type ReadMessageResult struct {
 func (result *ReadMessageResult) UnmarshalMessage() (*aws.Message, error) {
 
 	message := &aws.Message{}
-	err := proto.Unmarshal(result.Message[sizeOfMessageSize:], message)
+	err := proto.Unmarshal(result.Message[aws.SizeOfMessageSize:], message)
 	return message, err
 }
 

--- a/aws/const.go
+++ b/aws/const.go
@@ -1,0 +1,22 @@
+package aws
+
+import "errors"
+
+const (
+	QueryKeyProxyMode        = "local-proxy-mode"
+	SubProtocolV2            = "aws.iot.securetunneling-2.0"
+	HeaderKeyAccessToken     = "access-token"
+	HeaderKeyClientToken     = "client-token"
+	HeaderKeyStatusReason    = "X-Status-Reason"
+	StatusReasonTunnelClosed = "Tunnel is closed"
+	SizeOfMessageSize        = 2
+	MaxWebSocketFrameSize    = 131076
+)
+
+var (
+	ErrTunnelClosed = errors.New("Tunnel is closed")
+
+	SubProtocols = []string{
+		SubProtocolV2,
+	}
+)

--- a/client/awsclient_test.go
+++ b/client/awsclient_test.go
@@ -67,9 +67,9 @@ func (suite *AWSClientTest) TestConnect() {
 	request := <-server.ChRequest
 
 	// check request header
-	suite.Require().Equal(string(ModeDestination), request.FormValue(queryKeyProxyMode))
+	suite.Require().Equal(string(ModeDestination), request.FormValue(aws.QueryKeyProxyMode))
 	suite.Require().Equal([]string{options.Token}, request.Header["Access-Token"])
-	suite.Require().Equal(subProtocols, request.Header["Sec-Websocket-Protocol"])
+	suite.Require().Equal(aws.SubProtocols, request.Header["Sec-Websocket-Protocol"])
 
 	// wait for ping
 	<-server.ChPing
@@ -114,7 +114,7 @@ func (suite *AWSClientTest) TestReconnect() {
 
 		server.RequestHandler = func(w http.ResponseWriter, r *http.Request) bool {
 			if test.response.tunnelClosed {
-				w.Header().Set(headerKeyStatusReason, statusReasonTunnelClosed)
+				w.Header().Set(aws.HeaderKeyStatusReason, aws.StatusReasonTunnelClosed)
 			}
 			w.WriteHeader(test.response.statusCode)
 			return true
@@ -332,9 +332,9 @@ func (suite *AWSClientTest) TestReceivedMessageListenerReturnsError() {
 	request := <-server.ChRequest
 
 	// check request header
-	suite.Require().Equal(string(ModeDestination), request.FormValue(queryKeyProxyMode))
+	suite.Require().Equal(string(ModeDestination), request.FormValue(aws.QueryKeyProxyMode))
 	suite.Require().Equal([]string{options.Token}, request.Header["Access-Token"])
-	suite.Require().Equal(subProtocols, request.Header["Sec-Websocket-Protocol"])
+	suite.Require().Equal(aws.SubProtocols, request.Header["Sec-Websocket-Protocol"])
 
 	// -----------------------------
 	//  StreamStart message
@@ -624,7 +624,7 @@ func marshalMessages(messages []*aws.Message) ([]byte, error) {
 			return nil, err
 		}
 
-		sizeBin := make([]byte, sizeOfMessageSize)
+		sizeBin := make([]byte, aws.SizeOfMessageSize)
 		binary.BigEndian.PutUint16(sizeBin, uint16(len(messageBin)))
 
 		messagesBin = append(messagesBin, sizeBin...)

--- a/proxy/localproxy.go
+++ b/proxy/localproxy.go
@@ -56,6 +56,11 @@ func (options LocalProxyOptions) Validate() error {
 		return err
 	}
 
+	if options.Endpoint == nil {
+		err := errors.New("Endpoint is nil")
+		return err
+	}
+
 	switch options.Endpoint.Scheme {
 	case "ws", "wss":
 	default:
@@ -65,11 +70,6 @@ func (options LocalProxyOptions) Validate() error {
 
 	if len(options.ServiceConfigs) == 0 {
 		err := errors.New("ServiceConfigs is empty")
-		return err
-	}
-
-	if options.Endpoint == nil {
-		err := errors.New("Endpoint is nil")
 		return err
 	}
 


### PR DESCRIPTION
client package内の一部の定数を、aws packageに移動。
LocalProxyOptionsのValidateメソッドがバグっていたので一緒に修正してしまった。
