### PR TITLE
[#77] Match the path with the AWS service.

### DIFF
--- a/misc/server/cmd/mitra_tunneld/main.go
+++ b/misc/server/cmd/mitra_tunneld/main.go
@@ -104,7 +104,9 @@ func main() {
 		}
 	}
 
-	engine.GET("/tunnel/connect", server.PreProcess(svc.TunnelConnect))
+	// Since the local proxy made by AWS cannot change the path part,
+	// match the path with the AWS service.
+	engine.GET("/tunnel", server.PreProcess(svc.TunnelConnect))
 
 	// -----
 	//  Run


### PR DESCRIPTION
- 既存の /tunnel/connect は削除した。
- SSL化は別途リバースプロクシで対応すればいいので、今の所実装しない予定。
